### PR TITLE
small fix for play.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PY_LIBDIR=$(shell python -c 'import sysconfig as sc; print sc.get_config_var("LI
 
 PY_LIB=$(shell python -c 'import sysconfig as sc; print sc.get_config_var("LIBRARY")[3:-2]')
 
-.PHONY: all build clean
+.PHONY: all build test clean
 
 all: build
 
@@ -22,6 +22,9 @@ caplaymu: caplaymu.c
 clean:
 	@rm -f *.o *.so caplaymu 
 	@rm -rf build caplaymu.dSYM
+
+test:
+	@python3 play.py bimbam.wav
 
 build:
 	@python3 setup.py build

--- a/play.py
+++ b/play.py
@@ -62,7 +62,7 @@ def play(au, f):
         # pad the last frame with silence
         sil = frames * 2 - len(buf)
         if sil:
-            buf = buf + '\0' * sil
+            buf = buf + b'\0' * sil
         return (None, buf)
 
     done = threading.Condition()


### PR DESCRIPTION
@larsimmisch  Tiny change so that `play.py` works and plays audio for me, otherwise, I got the following error:

```python
Traceback (most recent call last):
  File "$HOME/projects/pycoreaudio/play.py", line 65, in render_callback
    buf = buf + '\0' * sil
          ~~~~^~~~~~~~~~~~
TypeError: can't concat str to bytes
```
Also so small change to Makefile.